### PR TITLE
DAIQIP #7 - Bond LP rewards in DAO, lower LP share, DAIQ treasury

### DIFF
--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -67,7 +67,7 @@ library Constants {
     /* Regulator */
     uint256 private constant SUPPLY_CHANGE_DIVISOR = 12e18; // 12
     uint256 private constant SUPPLY_CHANGE_LIMIT = 10e16; // 10%
-    uint256 private constant ORACLE_POOL_RATIO = 60; // 60%
+    uint256 private constant ORACLE_POOL_RATIO = 30; // 30%
 
     /**
      * Getters
@@ -162,6 +162,10 @@ library Constants {
 
     function getOraclePoolRatio() internal pure returns (uint256) {
         return ORACLE_POOL_RATIO;
+    }
+
+    function getTreasuryRatio() internal pure returns (uint256) {
+        return 5; //5% to treasury
     }
 
     function getChainId() internal pure returns (uint256) {

--- a/protocol/contracts/dao/Deployer.sol
+++ b/protocol/contracts/dao/Deployer.sol
@@ -48,7 +48,7 @@ contract Deployer2 is State, Permission, Upgradeable {
 
 contract Deployer3 is State, Permission, Upgradeable {
     function initialize() initializer public {
-        _state.provider.pool = address(new Pool(address(dollar()), address(oracle().pair())));
+        _state.provider.pool = address(new Pool());
     }
 
     function implement(address implementation) external {

--- a/protocol/contracts/dao/Getters.sol
+++ b/protocol/contracts/dao/Getters.sol
@@ -99,6 +99,10 @@ contract Getters is State {
         return dollar().totalSupply().sub(totalDebt());
     }
 
+    function treasury() public view returns (address) {
+        return Constants.getMultisigAddress();
+    }
+
     /**
      * Account
      */

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -31,11 +31,9 @@ contract Implementation is State, Bonding, Market, Regulator, Govern, Bootstrapp
     event Advance(uint256 indexed epoch, uint256 block, uint256 timestamp);
 
     function initialize() initializer public {
-        dai().transfer(0xC6c42995F7A033CE1Be6b9888422628f2AD67F63, 1000e18); //1000 DAI to D:\ev (reimbursing this + last deployment)
+        _state.provider.pool = address(0x7453A0737f756dfbBC91B7B86B81448Df0f2DD47);
+        dai().transfer(0xC6c42995F7A033CE1Be6b9888422628f2AD67F63, 1000e18); //1000 DAI to D:\ev
         dai().transfer(msg.sender, 150e18);  //150 DAI to committer
-
-        //allows the new coupon system to be used immediately
-        storePrice(epoch(), oracleCapture());
     }
 
     function advance() external {

--- a/protocol/contracts/dao/Market.sol
+++ b/protocol/contracts/dao/Market.sol
@@ -27,7 +27,7 @@ contract Market is Comptroller, Curve {
 
     bytes32 private constant FILE = "Market";
 
-    event CouponExpiration(uint256 indexed epoch, uint256 couponsExpired, uint256 lessRedeemable, uint256 lessDebt, uint256 newBonded);
+    event CouponExpiration(uint256 indexed epoch, uint256 couponsExpired, uint256 lessRedeemable, uint256 lessDebt, uint256 newBonded, uint256 newTreasury);
     event CouponPurchase(address indexed account, uint256 indexed epoch, uint256 dollarAmount, uint256 couponAmount);
     event CouponRedemption(address indexed account, uint256 indexed epoch, uint256 couponAmount);
     event CouponBurn(address indexed account, uint256 indexed epoch, uint256 couponAmount);
@@ -40,7 +40,7 @@ contract Market is Comptroller, Curve {
 
     function expireCouponsForEpoch(uint256 epoch) private {
         uint256 expiredAmount = expiringCoupons(epoch);
-        (uint256 lessRedeemable, uint256 lessDebt, uint256 newBonded) = (0, 0, 0);
+        (uint256 lessRedeemable, uint256 lessDebt, uint256 newBonded, uint256 newTreasury) = (0, 0, 0, 0);
 
         expireCoupons(epoch);
 
@@ -49,10 +49,10 @@ contract Market is Comptroller, Curve {
         if (totalRedeemable > totalCoupons) {
             lessRedeemable = totalRedeemable.sub(totalCoupons);
             burnRedeemable(lessRedeemable);
-            (, lessDebt, newBonded) = increaseSupply(lessRedeemable);
+            (, lessDebt, newBonded, newTreasury) = increaseSupply(lessRedeemable);
         }
 
-        emit CouponExpiration(epoch, expiredAmount, lessRedeemable, lessDebt, newBonded);
+        emit CouponExpiration(epoch, expiredAmount, lessRedeemable, lessDebt, newBonded, newTreasury);
     }
     
     function couponPremium(uint256 amount, uint256 expirationPeriod) public view returns (uint256) {

--- a/protocol/contracts/dao/Permission.sol
+++ b/protocol/contracts/dao/Permission.sol
@@ -46,6 +46,16 @@ contract Permission is Setters {
         _;
     }
 
+    modifier onlyPool(address account) {
+        Require.that(
+            _state.provider.pool == account,
+            FILE,
+            "Account isn't pool"
+        );
+
+        _;
+    }
+
     modifier initializer() {
         Require.that(
             !isInitialized(implementation()),

--- a/protocol/contracts/dao/Regulator.sol
+++ b/protocol/contracts/dao/Regulator.sol
@@ -26,7 +26,7 @@ contract Regulator is Comptroller {
     using SafeMath for uint256;
     using Decimal for Decimal.D256;
 
-    event SupplyIncrease(uint256 indexed epoch, uint256 epochPeriod, uint256 price, uint256 newRedeemable, uint256 lessDebt, uint256 newBonded);
+    event SupplyIncrease(uint256 indexed epoch, uint256 epochPeriod, uint256 price, uint256 newRedeemable, uint256 lessDebt, uint256 newBonded, uint256 newTreasury);
     event SupplyDecrease(uint256 indexed epoch, uint256 epochPeriod, uint256 price, uint256 newDebt);
     event SupplyNeutral(uint256 indexed epoch, uint256 epochPeriod);
 
@@ -62,8 +62,8 @@ contract Regulator is Comptroller {
     function growSupply(Decimal.D256 memory price) private {
         Decimal.D256 memory delta = limit(price.sub(Decimal.one()).div(Constants.getSupplyChangeDivisor()));
         uint256 newSupply = delta.mul(totalNet()).asUint256();
-        (uint256 newRedeemable, uint256 lessDebt, uint256 newBonded) = increaseSupply(newSupply);
-        emit SupplyIncrease(epoch(), currentEpochDuration(), price.value, newRedeemable, lessDebt, newBonded);
+        (uint256 newRedeemable, uint256 lessDebt, uint256 newBonded, uint256 newTreasury) = increaseSupply(newSupply);
+        emit SupplyIncrease(epoch(), currentEpochDuration(), price.value, newRedeemable, lessDebt, newBonded, newTreasury);
     }
 
     function limit(Decimal.D256 memory delta) internal view returns (Decimal.D256 memory) {

--- a/protocol/contracts/mock/MockPool.sol
+++ b/protocol/contracts/mock/MockPool.sol
@@ -25,7 +25,9 @@ contract MockPool is Pool {
     address private _dollar;
     address private _univ2;
 
-    constructor(address dollar, address dai, address univ2) Pool(dollar, univ2) public {
+    constructor(address dollar, address dai, address univ2) Pool() public {
+        _state.provider.dollar = IDollar(dollar);
+        _state.provider.univ2 = IERC20(univ2);
         _dai = dai;
     }
 

--- a/protocol/contracts/mock/MockRegulator.sol
+++ b/protocol/contracts/mock/MockRegulator.sol
@@ -23,8 +23,12 @@ import "./MockComptroller.sol";
 import "./MockState.sol";
 
 contract MockRegulator is MockComptroller, Regulator {
-    constructor (address oracle, address pool) MockComptroller(pool) public {
+
+    address private _treasury;
+
+    constructor (address oracle, address pool, address treasury) MockComptroller(pool) public {
         _state.provider.oracle = IOracle(oracle);
+        _treasury = treasury;
     }
 
     function stepE() external {
@@ -33,5 +37,9 @@ contract MockRegulator is MockComptroller, Regulator {
 
     function bootstrappingAt(uint256 epoch) public view returns (bool) {
         return epoch <= 5;
+    }
+
+    function treasury() public view returns (address) {
+        return _treasury;
     }
 }

--- a/protocol/contracts/mock/MockSettableDAO.sol
+++ b/protocol/contracts/mock/MockSettableDAO.sol
@@ -22,11 +22,17 @@ import "../oracle/IDAO.sol";
 contract MockSettableDAO is IDAO {
     uint256 internal _epoch;
 
+    mapping(address => uint256) public bonds;
+
     function set(uint256 epoch) external {
         _epoch = epoch;
     }
 
     function epoch() external view returns (uint256) {
         return _epoch;
+    }
+
+    function bondFromPool(address account, uint256 amount) external {
+      bonds[account] = bonds[account] + amount;
     }
 }

--- a/protocol/contracts/mock/MockState.sol
+++ b/protocol/contracts/mock/MockState.sol
@@ -167,4 +167,8 @@ contract MockState is Setters {
     function setBlockTimestamp(uint256 timestamp) external {
         _blockTimestamp = timestamp;
     }
+
+    function setPool(address pool) external {
+      _state.provider.pool = pool;
+    }
 }

--- a/protocol/contracts/oracle/IDAO.sol
+++ b/protocol/contracts/oracle/IDAO.sol
@@ -18,4 +18,5 @@ pragma solidity ^0.5.17;
 
 contract IDAO {
     function epoch() external view returns (uint256);
+    function bondFromPool(address account, uint256 value) external;
 }

--- a/protocol/test/dao/Market.test.js
+++ b/protocol/test/dao/Market.test.js
@@ -465,7 +465,8 @@ describe('Market', function () {
                     expect(event.args.couponsExpired).to.be.bignumber.equal(new BN(184961));
                     expect(event.args.lessRedeemable).to.be.bignumber.equal(new BN(100000));
                     expect(event.args.lessDebt).to.be.bignumber.equal(new BN(0));
-                    expect(event.args.newBonded).to.be.bignumber.equal(new BN(100000));
+                    expect(event.args.newBonded).to.be.bignumber.equal(new BN(95000));
+                    expect(event.args.newTreasury).bignumber.equal(new BN(5000));
                 });
             });
 
@@ -496,7 +497,8 @@ describe('Market', function () {
                     expect(event.args.epoch).to.be.bignumber.equal(new BN(12));
                     expect(event.args.couponsExpired).to.be.bignumber.equal(new BN(92480));
                     expect(event.args.lessDebt).to.be.bignumber.equal(new BN(0));
-                    expect(event.args.newBonded).to.be.bignumber.equal(new BN(27749));
+                    expect(event.args.newBonded).to.be.bignumber.equal(new BN(26362));
+                    expect(event.args.newTreasury).bignumber.equal(new BN(1387));
                 });
             });
 
@@ -528,6 +530,7 @@ describe('Market', function () {
                     expect(event.args.couponsExpired).to.be.bignumber.equal(new BN(113721));
                     expect(event.args.lessDebt).to.be.bignumber.equal(new BN(5497));
                     expect(event.args.newBonded).to.be.bignumber.equal(new BN(0));
+                    expect(event.args.newTreasury).bignumber.zero;
                 });
             });
 
@@ -558,7 +561,8 @@ describe('Market', function () {
                     expect(event.args.epoch).to.be.bignumber.equal(new BN(12));
                     expect(event.args.couponsExpired).to.be.bignumber.equal(new BN(96728));
                     expect(event.args.lessDebt).to.be.bignumber.equal(new BN(10000));
-                    expect(event.args.newBonded).to.be.bignumber.equal(new BN(13298));
+                    expect(event.args.newBonded).to.be.bignumber.equal(new BN(12634));
+                    expect(event.args.newTreasury).bignumber.equal(new BN(664));
                 });
             });
         });

--- a/protocol/test/oracle/Pool.test.js
+++ b/protocol/test/oracle/Pool.test.js
@@ -18,15 +18,15 @@ async function incrementEpoch(dao) {
 }
 
 describe('Pool', function () {
-  const [ ownerAddress, userAddress, userAddress1, userAddress2, mockDao ] = accounts;
+  const [ownerAddress, userAddress, userAddress1, userAddress2, mockDao] = accounts;
 
   beforeEach(async function () {
-    this.dao = await MockSettableDAO.new({from: ownerAddress, gas: 8000000});
+    this.dao = await MockSettableDAO.new({ from: ownerAddress, gas: 8000000 });
     await this.dao.set(1);
-    this.dollar = await MockToken.new("Daiquilibrium", "DAIQ", 18, {from: ownerAddress, gas: 8000000});
-    this.dai = await MockToken.new("DAI", "DAI", 18, {from: ownerAddress, gas: 8000000});
-    this.univ2 = await MockUniswapV2PairLiquidity.new({from: ownerAddress, gas: 8000000});
-    this.pool = await MockPool.new(this.dao.address, this.dai.address, this.univ2.address, {from: ownerAddress, gas: 8000000});
+    this.dollar = await MockToken.new("Daiquilibrium", "DAIQ", 18, { from: ownerAddress, gas: 8000000 });
+    this.dai = await MockToken.new("DAI", "DAI", 18, { from: ownerAddress, gas: 8000000 });
+    this.univ2 = await MockUniswapV2PairLiquidity.new({ from: ownerAddress, gas: 8000000 });
+    this.pool = await MockPool.new(this.dao.address, this.dai.address, this.univ2.address, { from: ownerAddress, gas: 8000000 });
     await this.pool.set(this.dao.address, this.dollar.address, this.univ2.address);
   });
 
@@ -40,9 +40,9 @@ describe('Pool', function () {
     describe('when deposit', function () {
       beforeEach(async function () {
         await this.univ2.faucet(userAddress, 1000);
-        await this.univ2.approve(this.pool.address, 1000, {from: userAddress});
+        await this.univ2.approve(this.pool.address, 1000, { from: userAddress });
 
-        this.result = await this.pool.deposit(1000, {from: userAddress});
+        this.result = await this.pool.deposit(1000, { from: userAddress });
         this.txHash = this.result.tx;
       });
 
@@ -75,10 +75,10 @@ describe('Pool', function () {
       describe('simple', function () {
         beforeEach(async function () {
           await this.univ2.faucet(userAddress, 1000);
-          await this.univ2.approve(this.pool.address, 1000, {from: userAddress});
-          await this.pool.deposit(1000, {from: userAddress});
+          await this.univ2.approve(this.pool.address, 1000, { from: userAddress });
+          await this.pool.deposit(1000, { from: userAddress });
 
-          this.result = await this.pool.withdraw(1000, {from: userAddress});
+          this.result = await this.pool.withdraw(1000, { from: userAddress });
           this.txHash = this.result.tx;
         });
 
@@ -110,16 +110,16 @@ describe('Pool', function () {
       describe('too much', function () {
         beforeEach(async function () {
           await this.univ2.faucet(userAddress, 1000);
-          await this.univ2.approve(this.pool.address, 1000, {from: userAddress});
-          await this.pool.deposit(1000, {from: userAddress});
+          await this.univ2.approve(this.pool.address, 1000, { from: userAddress });
+          await this.pool.deposit(1000, { from: userAddress });
 
           await this.univ2.faucet(userAddress1, 10000);
-          await this.univ2.approve(this.pool.address, 10000, {from: userAddress1});
-          await this.pool.deposit(10000, {from: userAddress1});
+          await this.univ2.approve(this.pool.address, 10000, { from: userAddress1 });
+          await this.pool.deposit(10000, { from: userAddress1 });
         });
 
         it('reverts', async function () {
-          await expectRevert(this.pool.withdraw(2000, {from: userAddress}), "insufficient staged balance");
+          await expectRevert(this.pool.withdraw(2000, { from: userAddress }), "insufficient staged balance");
         });
       });
     });
@@ -127,18 +127,18 @@ describe('Pool', function () {
     describe('when claim', function () {
       beforeEach(async function () {
         await this.univ2.faucet(userAddress, 1000);
-        await this.univ2.approve(this.pool.address, 1000, {from: userAddress});
-        await this.pool.deposit(1000, {from: userAddress});
-        await this.pool.bond(1000, {from: userAddress});
+        await this.univ2.approve(this.pool.address, 1000, { from: userAddress });
+        await this.pool.deposit(1000, { from: userAddress });
+        await this.pool.bond(1000, { from: userAddress });
         await this.dao.set((await this.dao.epoch()) + 1);
         await this.dollar.mint(this.pool.address, 1000);
-        await this.pool.unbond(1000, {from: userAddress});
+        await this.pool.unbond(1000, { from: userAddress });
         await this.dao.set((await this.dao.epoch()) + 1);
       });
 
       describe('simple', function () {
         beforeEach(async function () {
-          this.result = await this.pool.claim(1000, {from: userAddress});
+          this.result = await this.pool.claim(1000, { from: userAddress });
           this.txHash = this.result.tx;
         });
 
@@ -173,7 +173,7 @@ describe('Pool', function () {
         });
 
         it('reverts', async function () {
-          await expectRevert(this.pool.claim(2000, {from: userAddress}), "insufficient claimable balance");
+          await expectRevert(this.pool.claim(2000, { from: userAddress }), "insufficient claimable balance");
         });
       });
     });
@@ -183,10 +183,10 @@ describe('Pool', function () {
         describe('simple', function () {
           beforeEach(async function () {
             await this.univ2.faucet(userAddress, 1000);
-            await this.univ2.approve(this.pool.address, 1000, {from: userAddress});
-            await this.pool.deposit(1000, {from: userAddress});
+            await this.univ2.approve(this.pool.address, 1000, { from: userAddress });
+            await this.pool.deposit(1000, { from: userAddress });
 
-            this.result = await this.pool.bond(1000, {from: userAddress});
+            this.result = await this.pool.bond(1000, { from: userAddress });
             this.txHash = this.result.tx;
           });
 
@@ -219,10 +219,10 @@ describe('Pool', function () {
         describe('partial', function () {
           beforeEach(async function () {
             await this.univ2.faucet(userAddress, 1000);
-            await this.univ2.approve(this.pool.address, 1000, {from: userAddress});
-            await this.pool.deposit(800, {from: userAddress});
+            await this.univ2.approve(this.pool.address, 1000, { from: userAddress });
+            await this.pool.deposit(800, { from: userAddress });
 
-            this.result = await this.pool.bond(500, {from: userAddress});
+            this.result = await this.pool.bond(500, { from: userAddress });
             this.txHash = this.result.tx;
           });
 
@@ -255,23 +255,23 @@ describe('Pool', function () {
         describe('multiple', function () {
           beforeEach(async function () {
             await this.univ2.faucet(userAddress1, 1000);
-            await this.univ2.approve(this.pool.address, 1000, {from: userAddress1});
-            await this.pool.deposit(1000, {from: userAddress1});
+            await this.univ2.approve(this.pool.address, 1000, { from: userAddress1 });
+            await this.pool.deposit(1000, { from: userAddress1 });
 
             await this.univ2.faucet(userAddress2, 1000);
-            await this.univ2.approve(this.pool.address, 1000, {from: userAddress2});
-            await this.pool.deposit(1000, {from: userAddress2});
+            await this.univ2.approve(this.pool.address, 1000, { from: userAddress2 });
+            await this.pool.deposit(1000, { from: userAddress2 });
 
-            await this.pool.bond(600, {from: userAddress1});
-            await this.pool.bond(400, {from: userAddress2});
+            await this.pool.bond(600, { from: userAddress1 });
+            await this.pool.bond(400, { from: userAddress2 });
 
             await incrementEpoch(this.dao);
 
             await this.univ2.faucet(userAddress, 1000);
-            await this.univ2.approve(this.pool.address, 800, {from: userAddress});
-            await this.pool.deposit(800, {from: userAddress});
+            await this.univ2.approve(this.pool.address, 800, { from: userAddress });
+            await this.pool.deposit(800, { from: userAddress });
 
-            this.result = await this.pool.bond(500, {from: userAddress});
+            this.result = await this.pool.bond(500, { from: userAddress });
             this.txHash = this.result.tx;
           });
 
@@ -307,10 +307,10 @@ describe('Pool', function () {
           beforeEach(async function () {
             await this.univ2.faucet(userAddress, 1000);
             await this.dollar.mint(this.pool.address, 1000);
-            await this.univ2.approve(this.pool.address, 1000, {from: userAddress});
-            await this.pool.deposit(1000, {from: userAddress});
+            await this.univ2.approve(this.pool.address, 1000, { from: userAddress });
+            await this.pool.deposit(1000, { from: userAddress });
 
-            this.result = await this.pool.bond(1000, {from: userAddress});
+            this.result = await this.pool.bond(1000, { from: userAddress });
             this.txHash = this.result.tx;
           });
 
@@ -343,10 +343,10 @@ describe('Pool', function () {
         describe('after bond', function () {
           beforeEach(async function () {
             await this.univ2.faucet(userAddress, 1000);
-            await this.univ2.approve(this.pool.address, 1000, {from: userAddress});
-            await this.pool.deposit(800, {from: userAddress});
+            await this.univ2.approve(this.pool.address, 1000, { from: userAddress });
+            await this.pool.deposit(800, { from: userAddress });
 
-            this.result = await this.pool.bond(500, {from: userAddress});
+            this.result = await this.pool.bond(500, { from: userAddress });
             this.txHash = this.result.tx;
 
             await this.dollar.mint(this.pool.address, 1000);
@@ -382,24 +382,24 @@ describe('Pool', function () {
           beforeEach(async function () {
             await this.univ2.faucet(userAddress1, 1000);
             await this.dollar.mint(this.pool.address, new BN(1000));
-            await this.univ2.approve(this.pool.address, 1000, {from: userAddress1});
-            await this.pool.deposit(1000, {from: userAddress1});
+            await this.univ2.approve(this.pool.address, 1000, { from: userAddress1 });
+            await this.pool.deposit(1000, { from: userAddress1 });
 
             await this.univ2.faucet(userAddress2, 1000);
-            await this.univ2.approve(this.pool.address, 1000, {from: userAddress2});
-            await this.pool.deposit(1000, {from: userAddress2});
+            await this.univ2.approve(this.pool.address, 1000, { from: userAddress2 });
+            await this.pool.deposit(1000, { from: userAddress2 });
 
-            await this.pool.bond(600, {from: userAddress1});
-            await this.pool.bond(400, {from: userAddress2});
+            await this.pool.bond(600, { from: userAddress1 });
+            await this.pool.bond(400, { from: userAddress2 });
 
             await incrementEpoch(this.dao);
             await this.dollar.mint(this.pool.address, new BN(1000));
 
             await this.univ2.faucet(userAddress, 1000);
-            await this.univ2.approve(this.pool.address, 800, {from: userAddress});
-            await this.pool.deposit(800, {from: userAddress});
+            await this.univ2.approve(this.pool.address, 800, { from: userAddress });
+            await this.pool.deposit(800, { from: userAddress });
 
-            this.result = await this.pool.bond(500, {from: userAddress});
+            this.result = await this.pool.bond(500, { from: userAddress });
             this.txHash = this.result.tx;
           });
 
@@ -436,24 +436,24 @@ describe('Pool', function () {
         describe('multiple without reward first', function () {
           beforeEach(async function () {
             await this.univ2.faucet(userAddress1, 1000);
-            await this.univ2.approve(this.pool.address, 1000, {from: userAddress1});
-            await this.pool.deposit(1000, {from: userAddress1});
+            await this.univ2.approve(this.pool.address, 1000, { from: userAddress1 });
+            await this.pool.deposit(1000, { from: userAddress1 });
 
             await this.univ2.faucet(userAddress2, 1000);
-            await this.univ2.approve(this.pool.address, 1000, {from: userAddress2});
-            await this.pool.deposit(1000, {from: userAddress2});
+            await this.univ2.approve(this.pool.address, 1000, { from: userAddress2 });
+            await this.pool.deposit(1000, { from: userAddress2 });
 
-            await this.pool.bond(600, {from: userAddress1});
-            await this.pool.bond(400, {from: userAddress2});
+            await this.pool.bond(600, { from: userAddress1 });
+            await this.pool.bond(400, { from: userAddress2 });
 
             await incrementEpoch(this.dao);
             await this.dollar.mint(this.pool.address, new BN(1000).mul(INITIAL_STAKE_MULTIPLE));
 
             await this.univ2.faucet(userAddress, 1000);
-            await this.univ2.approve(this.pool.address, 800, {from: userAddress});
-            await this.pool.deposit(800, {from: userAddress});
+            await this.univ2.approve(this.pool.address, 800, { from: userAddress });
+            await this.pool.deposit(800, { from: userAddress });
 
-            this.result = await this.pool.bond(500, {from: userAddress});
+            this.result = await this.pool.bond(500, { from: userAddress });
             this.txHash = this.result.tx;
           });
 
@@ -489,20 +489,96 @@ describe('Pool', function () {
       });
     });
 
+    describe('when bondRewardsToDAO', function () {
+      beforeEach(async function () {
+        await this.univ2.faucet(userAddress, 1000);
+        await this.dollar.mint(this.pool.address, 1000);
+        await this.univ2.approve(this.pool.address, 1000, { from: userAddress });
+        await this.pool.deposit(1000, { from: userAddress });
+
+        await this.pool.bond(1000, { from: userAddress });
+
+        for (let i = 0; i < 12; i ++) {
+          await incrementEpoch(this.dao);
+        }
+      });
+
+      describe('single', function () {
+        beforeEach(async function () {
+          this.result = await this.pool.bondRewardsToDAO(1000, { from: userAddress });
+        });
+
+        it('updates user balance', async function () {
+          expect(await this.pool.balanceOfRewarded(userAddress)).bignumber.zero;
+          expect(await this.dollar.balanceOf(this.pool.address)).bignumber.zero;
+          expect(await this.pool.totalRewarded()).bignumber.zero;
+        });
+
+        it('calls bondFromPool', async function () {
+          expect(await this.dao.bonds(userAddress)).bignumber.equal(new BN(1000));
+        });
+
+        it('stays frozen', async function () {
+          expect(await this.pool.statusOf(userAddress)).bignumber.zero;
+        });
+      });
+
+      describe('partial', function () {
+        beforeEach(async function () {
+          this.result = await this.pool.bondRewardsToDAO(500, { from: userAddress });
+        });
+
+        it('updates user balance', async function () {
+          expect(await this.pool.balanceOfRewarded(userAddress)).bignumber.equal(new BN(500));
+          expect(await this.dollar.balanceOf(this.pool.address)).bignumber.equal(new BN(500));
+          expect(await this.pool.totalRewarded()).bignumber.equal(new BN(500));
+        });
+
+        it('calls bondFromPool', async function () {
+          expect(await this.dao.bonds(userAddress)).bignumber.equal(new BN(500));
+        });
+
+        it('stays frozen', async function () {
+          expect(await this.pool.statusOf(userAddress)).bignumber.zero;
+        });
+      });
+
+      describe('multiple', function () {
+        beforeEach(async function () {
+          await this.pool.bondRewardsToDAO(500, { from: userAddress });
+          await this.pool.bondRewardsToDAO(300, { from: userAddress });
+        });
+
+        it('updates user balance', async function () {
+          expect(await this.pool.balanceOfRewarded(userAddress)).bignumber.equal(new BN(200));
+          expect(await this.dollar.balanceOf(this.pool.address)).bignumber.equal(new BN(200));
+          expect(await this.pool.totalRewarded()).bignumber.equal(new BN(200));
+        });
+
+        it('calls bondFromPool', async function () {
+          expect(await this.dao.bonds(userAddress)).bignumber.equal(new BN(800));
+        });
+
+        it('stays frozen', async function () {
+          expect(await this.pool.statusOf(userAddress)).bignumber.zero;
+        });
+      });
+    });
+
     describe('when unbond', function () {
       describe('without reward', function () {
         beforeEach(async function () {
           await this.univ2.faucet(userAddress, 1000);
-          await this.univ2.approve(this.pool.address, 1000, {from: userAddress});
-          await this.pool.deposit(1000, {from: userAddress});
+          await this.univ2.approve(this.pool.address, 1000, { from: userAddress });
+          await this.pool.deposit(1000, { from: userAddress });
 
-          await this.pool.bond(1000, {from: userAddress});
+          await this.pool.bond(1000, { from: userAddress });
           await incrementEpoch(this.dao);
         });
 
         describe('simple', function () {
           beforeEach(async function () {
-            this.result = await this.pool.unbond(new BN(1000), {from: userAddress});
+            this.result = await this.pool.unbond(new BN(1000), { from: userAddress });
             this.txHash = this.result.tx;
           });
 
@@ -535,7 +611,7 @@ describe('Pool', function () {
 
         describe('partial', function () {
           beforeEach(async function () {
-            this.result = await this.pool.unbond(new BN(800), {from: userAddress});
+            this.result = await this.pool.unbond(new BN(800), { from: userAddress });
             this.txHash = this.result.tx;
           });
 
@@ -569,19 +645,19 @@ describe('Pool', function () {
         describe('multiple', function () {
           beforeEach(async function () {
             await this.univ2.faucet(userAddress1, 1000);
-            await this.univ2.approve(this.pool.address, 1000, {from: userAddress1});
-            await this.pool.deposit(1000, {from: userAddress1});
+            await this.univ2.approve(this.pool.address, 1000, { from: userAddress1 });
+            await this.pool.deposit(1000, { from: userAddress1 });
 
             await this.univ2.faucet(userAddress2, 1000);
-            await this.univ2.approve(this.pool.address, 1000, {from: userAddress2});
-            await this.pool.deposit(1000, {from: userAddress2});
+            await this.univ2.approve(this.pool.address, 1000, { from: userAddress2 });
+            await this.pool.deposit(1000, { from: userAddress2 });
 
-            await this.pool.bond(600, {from: userAddress1});
-            await this.pool.bond(400, {from: userAddress2});
+            await this.pool.bond(600, { from: userAddress1 });
+            await this.pool.bond(400, { from: userAddress2 });
 
             await incrementEpoch(this.dao);
 
-            this.result = await this.pool.unbond(new BN(800), {from: userAddress});
+            this.result = await this.pool.unbond(new BN(800), { from: userAddress });
             this.txHash = this.result.tx;
           });
 
@@ -616,17 +692,17 @@ describe('Pool', function () {
       describe('with reward', function () {
         beforeEach(async function () {
           await this.univ2.faucet(userAddress, 1000);
-          await this.univ2.approve(this.pool.address, 1000, {from: userAddress});
-          await this.pool.deposit(1000, {from: userAddress});
+          await this.univ2.approve(this.pool.address, 1000, { from: userAddress });
+          await this.pool.deposit(1000, { from: userAddress });
 
-          await this.pool.bond(1000, {from: userAddress});
+          await this.pool.bond(1000, { from: userAddress });
           await incrementEpoch(this.dao);
           await this.dollar.mint(this.pool.address, 1000);
         });
 
         describe('simple', function () {
           beforeEach(async function () {
-            this.result = await this.pool.unbond(new BN(1000), {from: userAddress});
+            this.result = await this.pool.unbond(new BN(1000), { from: userAddress });
             this.txHash = this.result.tx;
           });
 
@@ -661,7 +737,7 @@ describe('Pool', function () {
 
         describe('partial', function () {
           beforeEach(async function () {
-            this.result = await this.pool.unbond(new BN(800), {from: userAddress});
+            this.result = await this.pool.unbond(new BN(800), { from: userAddress });
             this.txHash = this.result.tx;
           });
 
@@ -697,20 +773,20 @@ describe('Pool', function () {
         describe('multiple', function () {
           beforeEach(async function () {
             await this.univ2.faucet(userAddress1, 1000);
-            await this.univ2.approve(this.pool.address, 1000, {from: userAddress1});
-            await this.pool.deposit(1000, {from: userAddress1});
+            await this.univ2.approve(this.pool.address, 1000, { from: userAddress1 });
+            await this.pool.deposit(1000, { from: userAddress1 });
 
             await this.univ2.faucet(userAddress2, 1000);
-            await this.univ2.approve(this.pool.address, 1000, {from: userAddress2});
-            await this.pool.deposit(1000, {from: userAddress2});
+            await this.univ2.approve(this.pool.address, 1000, { from: userAddress2 });
+            await this.pool.deposit(1000, { from: userAddress2 });
 
-            await this.pool.bond(600, {from: userAddress1});
-            await this.pool.bond(400, {from: userAddress2});
+            await this.pool.bond(600, { from: userAddress1 });
+            await this.pool.bond(400, { from: userAddress2 });
 
             await incrementEpoch(this.dao);
             await this.dollar.mint(this.pool.address, 1000);
 
-            this.result = await this.pool.unbond(new BN(800), {from: userAddress});
+            this.result = await this.pool.unbond(new BN(800), { from: userAddress });
             this.txHash = this.result.tx;
           });
 
@@ -752,24 +828,24 @@ describe('Pool', function () {
         describe('potential subtraction underflow', function () {
           beforeEach(async function () {
             await this.univ2.faucet(userAddress1, 1000);
-            await this.univ2.approve(this.pool.address, 1000, {from: userAddress1});
-            await this.pool.deposit(1000, {from: userAddress1});
+            await this.univ2.approve(this.pool.address, 1000, { from: userAddress1 });
+            await this.pool.deposit(1000, { from: userAddress1 });
 
             await this.univ2.faucet(userAddress2, 1000);
-            await this.univ2.approve(this.pool.address, 1000, {from: userAddress2});
-            await this.pool.deposit(1000, {from: userAddress2});
+            await this.univ2.approve(this.pool.address, 1000, { from: userAddress2 });
+            await this.pool.deposit(1000, { from: userAddress2 });
 
-            await this.pool.bond(600, {from: userAddress1});
-            await this.pool.bond(500, {from: userAddress2});
+            await this.pool.bond(600, { from: userAddress1 });
+            await this.pool.bond(500, { from: userAddress2 });
 
             await incrementEpoch(this.dao);
             await this.dollar.mint(this.pool.address, 1000);
 
-            await this.pool.unbond(new BN(1000), {from: userAddress});
-            await this.pool.bond(new BN(1000), {from: userAddress});
-            await this.pool.unbond(new BN(600), {from: userAddress});
+            await this.pool.unbond(new BN(1000), { from: userAddress });
+            await this.pool.bond(new BN(1000), { from: userAddress });
+            await this.pool.unbond(new BN(600), { from: userAddress });
 
-            this.result = await this.pool.unbond(new BN(200), {from: userAddress});
+            this.result = await this.pool.unbond(new BN(200), { from: userAddress });
             this.txHash = this.result.tx;
           });
 
@@ -813,9 +889,9 @@ describe('Pool', function () {
     describe('when provide', function () {
       beforeEach(async function () {
         await this.univ2.faucet(userAddress, 1000);
-        await this.univ2.approve(this.pool.address, 1000, {from: userAddress});
-        await this.pool.deposit(1000, {from: userAddress});
-        await this.pool.bond(1000, {from: userAddress});
+        await this.univ2.approve(this.pool.address, 1000, { from: userAddress });
+        await this.pool.deposit(1000, { from: userAddress });
+        await this.pool.bond(1000, { from: userAddress });
 
         this.poolLockupEpochs = 12;
         for (var i = 0; i < this.poolLockupEpochs; i++) {
@@ -826,7 +902,7 @@ describe('Pool', function () {
 
       describe('not enough rewards', function () {
         it('reverts', async function () {
-          await expectRevert(this.pool.provide(2000, {from: userAddress}), "Pool: insufficient rewarded balance");
+          await expectRevert(this.pool.provide(2000, { from: userAddress }), "Pool: insufficient rewarded balance");
         });
       });
 
@@ -836,11 +912,11 @@ describe('Pool', function () {
 
         beforeEach(async function () {
           await this.dai.mint(userAddress, 1000);
-          await this.dai.approve(this.pool.address, 1000, {from: userAddress});
+          await this.dai.approve(this.pool.address, 1000, { from: userAddress });
 
           await this.univ2.set(1000, 1000, 10);
 
-          this.result = await this.pool.provide(1000, {from: userAddress});
+          this.result = await this.pool.provide(1000, { from: userAddress });
           this.txHash = this.result.tx;
         });
 
@@ -884,12 +960,12 @@ describe('Pool', function () {
 
         beforeEach(async function () {
           await this.dai.mint(userAddress, 3000);
-          await this.dai.approve(this.pool.address, 3000, {from: userAddress});
+          await this.dai.approve(this.pool.address, 3000, { from: userAddress });
 
           await this.univ2.faucet(userAddress1, 1000);
-          await this.univ2.approve(this.pool.address, 1000, {from: userAddress1});
-          await this.pool.deposit(1000, {from: userAddress1});
-          await this.pool.bond(1000, {from: userAddress1});
+          await this.univ2.approve(this.pool.address, 1000, { from: userAddress1 });
+          await this.pool.deposit(1000, { from: userAddress1 });
+          await this.pool.bond(1000, { from: userAddress1 });
 
           await incrementEpoch(this.dao);
           await this.dollar.mint(this.pool.address, 1000);
@@ -897,7 +973,7 @@ describe('Pool', function () {
           // 1000 DSD + 3000 dai
           await this.univ2.set(1000, 3000, 10);
 
-          this.result = await this.pool.provide(1000, {from: userAddress});
+          this.result = await this.pool.provide(1000, { from: userAddress });
           this.txHash = this.result.tx;
         });
 
@@ -940,10 +1016,10 @@ describe('Pool', function () {
     beforeEach(async function () {
       await this.dollar.mint(this.pool.address, 1000);
       await this.univ2.faucet(userAddress, 1000);
-      await this.univ2.approve(this.pool.address, 1000, {from: userAddress});
-      await this.pool.deposit(1000, {from: userAddress});
+      await this.univ2.approve(this.pool.address, 1000, { from: userAddress });
+      await this.pool.deposit(1000, { from: userAddress });
 
-      await this.pool.bond(500, {from: userAddress});
+      await this.pool.bond(500, { from: userAddress });
     });
 
     it('is fluid', async function () {
@@ -953,32 +1029,32 @@ describe('Pool', function () {
     describe('when deposit', function () {
       it('completes', async function () {
         await this.univ2.faucet(userAddress, 1000);
-        await this.univ2.approve(this.pool.address, 1000, {from: userAddress});
-        await this.pool.deposit(1000, {from: userAddress});
+        await this.univ2.approve(this.pool.address, 1000, { from: userAddress });
+        await this.pool.deposit(1000, { from: userAddress });
       });
     });
 
     describe('when withdraw', function () {
       it('reverts', async function () {
-        await expectRevert(this.pool.withdraw(1000, {from: userAddress}), "Pool: Not frozen");
+        await expectRevert(this.pool.withdraw(1000, { from: userAddress }), "Pool: Not frozen");
       });
     });
 
     describe('when claim', function () {
       it('reverts', async function () {
-        await expectRevert(this.pool.claim(1000, {from: userAddress}), "Pool: Not frozen");
+        await expectRevert(this.pool.claim(1000, { from: userAddress }), "Pool: Not frozen");
       });
     });
 
     describe('when provide', function () {
       it('reverts', async function () {
-        await expectRevert(this.pool.provide(1000, {from: userAddress}), "Pool: Not frozen");
+        await expectRevert(this.pool.provide(1000, { from: userAddress }), "Pool: Not frozen");
       });
     });
 
     describe('when bond', function () {
       beforeEach(async function () {
-        this.result = await this.pool.bond(500, {from: userAddress});
+        this.result = await this.pool.bond(500, { from: userAddress });
         this.txHash = this.result.tx;
       });
 
@@ -1010,7 +1086,7 @@ describe('Pool', function () {
 
     describe('when unbond', function () {
       beforeEach(async function () {
-        this.result = await this.pool.unbond(new BN(500), {from: userAddress});
+        this.result = await this.pool.unbond(new BN(500), { from: userAddress });
         this.txHash = this.result.tx;
       });
 
@@ -1045,19 +1121,19 @@ describe('Pool', function () {
   describe('when pause', function () {
     beforeEach(async function () {
       await this.univ2.faucet(userAddress, 1000);
-      await this.univ2.approve(this.pool.address, 1000, {from: userAddress});
-      await this.pool.deposit(1000, {from: userAddress});
-      await this.pool.bond(1000, {from: userAddress});
+      await this.univ2.approve(this.pool.address, 1000, { from: userAddress });
+      await this.pool.deposit(1000, { from: userAddress });
+      await this.pool.bond(1000, { from: userAddress });
       await this.dao.set((await this.dao.epoch()) + 1);
       await this.dollar.mint(this.pool.address, 1000);
-      await this.pool.unbond(500, {from: userAddress});
+      await this.pool.unbond(500, { from: userAddress });
       await this.dao.set((await this.dao.epoch()) + 1);
     });
 
     describe('as dao', function () {
       beforeEach(async function () {
         await this.pool.set(mockDao, this.dollar.address, this.univ2.address);
-        await this.pool.emergencyPause({from: mockDao});
+        await this.pool.emergencyPause({ from: mockDao });
         await this.pool.set(this.dao.address, this.dollar.address, this.univ2.address);
       });
 
@@ -1066,20 +1142,20 @@ describe('Pool', function () {
       });
 
       it('reverts on deposit', async function () {
-        await expectRevert(this.pool.deposit(2000, {from: userAddress}), "Paused");
+        await expectRevert(this.pool.deposit(2000, { from: userAddress }), "Paused");
       });
 
       it('reverts on bond', async function () {
-        await expectRevert(this.pool.bond(2000, {from: userAddress}), "Paused");
+        await expectRevert(this.pool.bond(2000, { from: userAddress }), "Paused");
       });
 
       it('reverts on provide', async function () {
-        await expectRevert(this.pool.provide(2000, {from: userAddress}), "Paused");
+        await expectRevert(this.pool.provide(2000, { from: userAddress }), "Paused");
       });
 
       describe('withdraw', function () {
         beforeEach(async function () {
-          await this.pool.withdraw(200, {from: userAddress})
+          await this.pool.withdraw(200, { from: userAddress })
         });
 
         it('basic withdraw check', async function () {
@@ -1089,7 +1165,7 @@ describe('Pool', function () {
 
       describe('unbond', function () {
         beforeEach(async function () {
-          await this.pool.unbond(200, {from: userAddress})
+          await this.pool.unbond(200, { from: userAddress })
         });
 
         it('basic unbond check', async function () {
@@ -1100,7 +1176,7 @@ describe('Pool', function () {
 
       describe('claim', function () {
         beforeEach(async function () {
-          await this.pool.claim(200, {from: userAddress})
+          await this.pool.claim(200, { from: userAddress })
         });
 
         it('basic claim check', async function () {
@@ -1111,7 +1187,7 @@ describe('Pool', function () {
 
     describe('as not dao', function () {
       it('reverts', async function () {
-        await expectRevert(this.pool.emergencyPause({from: userAddress}), "Not dao");
+        await expectRevert(this.pool.emergencyPause({ from: userAddress }), "Not dao");
       });
     });
   });
@@ -1119,9 +1195,9 @@ describe('Pool', function () {
   describe('when emergency withdraw', function () {
     beforeEach(async function () {
       await this.univ2.faucet(userAddress, 1000);
-      await this.univ2.approve(this.pool.address, 1000, {from: userAddress});
-      await this.pool.deposit(1000, {from: userAddress});
-      await this.pool.bond(1000, {from: userAddress});
+      await this.univ2.approve(this.pool.address, 1000, { from: userAddress });
+      await this.pool.deposit(1000, { from: userAddress });
+      await this.pool.bond(1000, { from: userAddress });
       await this.dao.set((await this.dao.epoch()) + 1);
       await this.dollar.mint(this.pool.address, 1000);
     });
@@ -1129,8 +1205,8 @@ describe('Pool', function () {
     describe('as dao', function () {
       beforeEach(async function () {
         await this.pool.set(mockDao, this.dollar.address, this.univ2.address);
-        await this.pool.emergencyWithdraw(this.univ2.address, 1000, {from: mockDao});
-        await this.pool.emergencyWithdraw(this.dollar.address, 1000, {from: mockDao});
+        await this.pool.emergencyWithdraw(this.univ2.address, 1000, { from: mockDao });
+        await this.pool.emergencyWithdraw(this.dollar.address, 1000, { from: mockDao });
       });
 
       it('transfers funds to the dao', async function () {
@@ -1143,7 +1219,7 @@ describe('Pool', function () {
 
     describe('as not dao', function () {
       it('reverts', async function () {
-        await expectRevert(this.pool.emergencyWithdraw(this.univ2.address, 1000, {from: userAddress}), "Not dao");
+        await expectRevert(this.pool.emergencyWithdraw(this.univ2.address, 1000, { from: userAddress }), "Not dao");
       });
     });
   });


### PR DESCRIPTION
DAIQIP-7 implements the following changes:

- LP share lowered from 60 % to 30%
- DAO share raised from 40% to 65%
- 5% of expansions is now redirected to the treasury for future usage (governance)
- Implemented the bondRewardsToDAO function. While frozen, LP rewards can be bonded directly in DAO without claiming.
- Migration to Pool at address `0x7453a0737f756dfbbc91b7b86b81448df0f2dd47`

The implementation is available here: https://etherscan.io/address/0x08629f7ac0441f29bbc8ae2cfb2658acadf4d031#code