### PR TITLE
DAIQIP #9 - Buybacks

### DIFF
--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -35,13 +35,18 @@ contract Implementation is State, Bonding, Market, Regulator, Govern, Bootstrapp
         dai().transfer(0xC6c42995F7A033CE1Be6b9888422628f2AD67F63, 1000e18); //1000 DAI to D:\ev
         dai().transfer(msg.sender, 150e18);  //150 DAI to committer
 
-        uint256[] memory prizes = new uint256[](3);
-        prizes[0] = 50000e18;
-        prizes[1] = 30000e18;
-        prizes[2] = 20000e18;
-        lottery().newGame(prizes);
-
-        setEra(Era.Status.DEBT, epoch());
+        //Sends 400k yearn shares to the marketing multisig.
+        //This money will be used to reimburse the buyback team after the buyback happens.
+        //Any excess will be sent back to the treasury.
+        IVault(treasury()).submitTransaction(
+            0x19D3364A399d251E894aC732651be8B0E4e85001,
+            0,
+            abi.encodeWithSignature(
+                "transfer(address,uint256)",
+                Constants.getMarketingMultisigAddress(),
+                uint256(400000e18)
+            )
+        );
     }
 
     function advance() external {


### PR DESCRIPTION
This proposal sends 400.000 yearn shares to the marketing multisig.

A few selected community/team members will use their own funds to perform buybacks and support the price. After the buybacks are done, the team will release a document containing every transaction related to the buyback program.
The purchased DAIQ will then be sent to the treasury and the buyback wallets will be refunded with the exact amount of DAI used during the buyback. 
We aren't doing direct buybacks through a contract to prevent malicious actors from exploiting the system.
We aren't planning to use 400.000 DAI to buyback, every excess will be sent back to the treasury.

The implementation is deployed here: https://etherscan.io/address/0xd3a0c5fe67adaeaa087c607d4c5b8e4fc4f94a32#code